### PR TITLE
fix(order): Order 엔티티 테이블명 수정 및 기타 개선사항 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     implementation 'org.springframework.plugin:spring-plugin-core:3.0.0'
+
+    //aop
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderEntity.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderEntity.java
@@ -10,7 +10,7 @@ import xyz.tomorrowlearncamp.outsourcing.domain.user.entity.UserEntity;
 
 @Getter
 @Entity
-@Table(name = "order")
+@Table(name = "order_entity")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserOrderEntity {
 

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderEntity.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderEntity.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
 import xyz.tomorrowlearncamp.outsourcing.domain.store.entity.StoreEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.user.entity.UserEntity;
+import xyz.tomorrowlearncamp.outsourcing.global.exception.InvalidRequestException;
 
 @Getter
 @Entity
@@ -36,13 +37,18 @@ public class UserOrderEntity {
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
-    public UserOrderEntity(int totalPrice, String payment) {
+    public UserOrderEntity(UserEntity user/*, StoreEntity store,*/,  int totalPrice, String payment) {
+        this.user = user;
+//      this.store = store;
         this.totalPrice = totalPrice;
         this.payment = payment;
         this.orderStatus = OrderStatus.PENDING; // 기본값 설정
     }
 
     public void updateOrderStatus(OrderStatus orderStatus) {
+        if (this.orderStatus == OrderStatus.CANCELED) {
+            throw new InvalidRequestException("취소된 주문은 상태를 변경할 수 없습니다.");
+        }
         this.orderStatus = orderStatus;
     }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderListEntity.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderListEntity.java
@@ -8,7 +8,7 @@ import xyz.tomorrowlearncamp.outsourcing.domain.menu.entity.MenuEntity;
 
 @Getter
 @Entity
-@Table(name = "order_list")
+@Table(name = "order_list_entity")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserOrderListEntity {
 

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderListEntity.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderListEntity.java
@@ -17,7 +17,7 @@ public class UserOrderListEntity {
     private Long id;
 
     @Column(nullable = false)
-    private int count;
+    private int quantity;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id", nullable = false)
@@ -27,8 +27,9 @@ public class UserOrderListEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private UserOrderEntity order;
 
-    public UserOrderListEntity(MenuEntity menu, UserOrderEntity order) {
+    public UserOrderListEntity(MenuEntity menu, UserOrderEntity order, int quantity) {
         this.menu = menu;
         this.order = order;
+        this.quantity = quantity;
     }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/OwnerOrderService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/OwnerOrderService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.ErrorOrderMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.repository.OrderRepository;
 import xyz.tomorrowlearncamp.outsourcing.global.exception.InvalidRequestException;
@@ -22,11 +23,11 @@ public class OwnerOrderService {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
-            throw new InvalidRequestException("본인의 가게 주문만 수락할 수 있습니다.");
+            throw new InvalidRequestException(ErrorOrderMessage.ONLY_OWNER_CAN_ACCEPT.getMessage());
         }
 
         if (!OrderStatus.PENDING.equals(order.getOrderStatus())) {
-            throw new InvalidRequestException("주문을 취소할 수 없습니다.");
+            throw new InvalidRequestException(ErrorOrderMessage.CANNOT_CANCEL_ORDER.getMessage());
         }
 
         order.updateOrderStatus(OrderStatus.ACCEPTED);
@@ -37,11 +38,11 @@ public class OwnerOrderService {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
-            throw new InvalidRequestException("본인의 가게 주문만 거절할 수 있습니다.");
+            throw new InvalidRequestException(ErrorOrderMessage.ONLY_OWNER_CAN_REJECT.getMessage());
         }
 
         if (!OrderStatus.PENDING.equals(order.getOrderStatus())) {
-            throw new InvalidRequestException("주문을 취소할 수 없습니다.");
+            throw new InvalidRequestException(ErrorOrderMessage.CANNOT_CANCEL_ORDER.getMessage());
         }
 
         order.updateOrderStatus(OrderStatus.REJECTED);

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/UserOrderListService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/UserOrderListService.java
@@ -9,10 +9,10 @@ import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderListEntity
 import xyz.tomorrowlearncamp.outsourcing.domain.order.repository.OrderListRepository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class UserOrderListService {
 
     private final OrderListRepository orderListRepository;
@@ -20,8 +20,8 @@ public class UserOrderListService {
     @Transactional
     public void saveOrderList(UserOrderEntity order, List<CartEntity> cartItems) {
         List<UserOrderListEntity> orderLists = cartItems.stream()
-                .map(cart -> new UserOrderListEntity(cart.getMenu(), order))
-                .toList();
+                .map(cart -> new UserOrderListEntity(cart.getMenu(), order, cart.getQuantity()))
+                .collect(Collectors.toList());
         orderListRepository.saveAll(orderLists);
     }
 

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/UserOrderService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/UserOrderService.java
@@ -13,6 +13,8 @@ import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.ErrorOrderMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.repository.OrderRepository;
+import xyz.tomorrowlearncamp.outsourcing.domain.user.entity.UserEntity;
+import xyz.tomorrowlearncamp.outsourcing.domain.user.service.UserService;
 import xyz.tomorrowlearncamp.outsourcing.global.exception.InvalidRequestException;
 
 import java.util.List;
@@ -26,9 +28,12 @@ public class UserOrderService {
     private final OrderRepository orderRepository;
     private final UserOrderListService userOrderListService;
     private final UserCartService userCartService;
+    private final UserService userService;
 
     @Transactional
     public PlaceOrderResponseDto placeOrder(Long userId, @Valid PlaceOrderRequestDto dto) {
+
+        UserEntity user = userService.getUserEntity(userId);
         List<CartEntity> cartItems = userCartService.getCartItems(userId);
         if (cartItems.isEmpty()) {
             throw new InvalidRequestException(ErrorCartMessage.EMPTY_CART.getMessage());
@@ -50,7 +55,7 @@ public class UserOrderService {
 //            throw new InvalidRequestException(ErrorOrderMessage.MINIMUM_ORDER_NOT_MET.getMessage());
 //        }
 
-        UserOrderEntity order = new UserOrderEntity(totalPrice, dto.getPayment());
+        UserOrderEntity order = new UserOrderEntity(user/*, store*/, totalPrice, dto.getPayment());
         orderRepository.save(order);
 
         userOrderListService.saveOrderList(order, cartItems);


### PR DESCRIPTION
- `Order` 엔티티 테이블명 수정
- AOP 의존성 추가
- 에러 메세지 수정 안된 부분 추가
- `UserOrderEntity` 생성자에 `user`와 `store` 추가
- `store`는 연결 전이라 주석 처리
- `UserOrderEntity`에서 `updateOrderStatus()` 메서드에 이미 취소된 주문의 상태를 변경할 수 없도록 수정
 - 리스트로 변환 시 `toList()`에서 `Collectors.toList()`로 수정
 - 불필요한 `Transactional(readOnly = true)` 제거
 - `UserOrderListEntity`에 수량도 같이 저장되도록 수정