### PR TITLE
feat(order): 주문 상태 API 추가 및 AOP 로깅 구현

### DIFF
--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/cart/dto/response/AddCartResponseDto.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/cart/dto/response/AddCartResponseDto.java
@@ -7,15 +7,15 @@ import xyz.tomorrowlearncamp.outsourcing.domain.cart.entity.CartEntity;
 public class AddCartResponseDto {
 
     private final Long id;
-//    private final String storeName;
+    private final String storeName;
     private final String menuName;
     private final int menuPrice;
     private final String menuImageUrl;
     private final int quantity;
 
-    public AddCartResponseDto(Long id/* ,String storeName */, String menuName, int menuPrice, String menuImageUrl, int quantity) {
+    public AddCartResponseDto(Long id ,String storeName, String menuName, int menuPrice, String menuImageUrl, int quantity) {
         this.id = id;
-//        this.storeName = storeName;
+        this.storeName = storeName;
         this.menuName = menuName;
         this.menuPrice = menuPrice;
         this.menuImageUrl = menuImageUrl;
@@ -25,7 +25,7 @@ public class AddCartResponseDto {
     public static AddCartResponseDto from(CartEntity cart) {
         return new AddCartResponseDto(
                 cart.getId(),
-//                cart.getMenu().getStore().getName(),
+                cart.getMenu().getStore().getStoreTitle(),
                 cart.getMenu().getMenuName(),
                 cart.getMenu().getMenuPrice(),
                 cart.getMenu().getMenuImageUrl(),

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/cart/service/UserCartService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/cart/service/UserCartService.java
@@ -10,7 +10,7 @@ import xyz.tomorrowlearncamp.outsourcing.domain.cart.entity.CartEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.cart.enums.ErrorCartMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.cart.repository.CartRepository;
 import xyz.tomorrowlearncamp.outsourcing.domain.menu.entity.MenuEntity;
-import xyz.tomorrowlearncamp.outsourcing.domain.menu.enums.MenuErrorMessage;
+import xyz.tomorrowlearncamp.outsourcing.domain.menu.enums.ErrorMenuMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.menu.repository.MenuRepository;
 import xyz.tomorrowlearncamp.outsourcing.domain.user.entity.UserEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.user.service.UserService;
@@ -35,7 +35,7 @@ public class UserCartService {
         UserEntity user = userService.getUserEntity(userId);
 
         MenuEntity menu = menuRepository.findById(dto.getMenuId())
-                .orElseThrow(() -> new InvalidRequestException(MenuErrorMessage.NOT_FOUND_MENU.getErrorMessage()));
+                .orElseThrow(() -> new InvalidRequestException(ErrorMenuMessage.NOT_FOUND_MENU.getErrorMessage()));
 
         CartEntity cart = cartRepository.findByUserIdAndMenuId(userId, dto.getMenuId())
                 .map(existingCart -> {

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/controller/OwnerOrderController.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/controller/OwnerOrderController.java
@@ -3,7 +3,9 @@ package xyz.tomorrowlearncamp.outsourcing.domain.order.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.OrderStatusResponseDto;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.service.OwnerOrderService;
+import xyz.tomorrowlearncamp.outsourcing.global.config.aop.annotation.Order;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,48 +14,48 @@ public class OwnerOrderController {
 
     private final OwnerOrderService ownerOrderService;
 
+    @Order
     @PatchMapping("/{orderId}/accept")
-    public ResponseEntity<Void> acceptOrder(
+    public ResponseEntity<OrderStatusResponseDto> acceptOrder(
             @SessionAttribute(name = "LOGIN_USER") Long ownerId,
             @PathVariable Long orderId
     ) {
-        ownerOrderService.acceptOrder(ownerId, orderId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ownerOrderService.acceptOrder(ownerId, orderId));
     }
 
+    @Order
     @PatchMapping("/{orderId}/reject")
-    public ResponseEntity<Void> rejectOrder(
+    public ResponseEntity<OrderStatusResponseDto> rejectOrder(
             @SessionAttribute(name = "LOGIN_USER") Long ownerId,
             @PathVariable Long orderId
     ) {
-        ownerOrderService.rejectOrder(ownerId, orderId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ownerOrderService.rejectOrder(ownerId, orderId));
     }
 
+    @Order
     @PatchMapping("/{orderId}/cook")
-    public ResponseEntity<Void> startCooking(
+    public ResponseEntity<OrderStatusResponseDto> startCooking(
             @SessionAttribute(name = "LOGIN_USER") Long ownerId,
             @PathVariable Long orderId
     ) {
-        ownerOrderService.startCooking(ownerId, orderId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ownerOrderService.startCooking(ownerId, orderId));
     }
 
+    @Order
     @PatchMapping("/{orderId}/deliver")
-    public ResponseEntity<Void> startDelivery(
+    public ResponseEntity<OrderStatusResponseDto> startDelivery(
             @SessionAttribute(name = "LOGIN_USER") Long ownerId,
             @PathVariable Long orderId
     ) {
-        ownerOrderService.startDelivery(ownerId, orderId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ownerOrderService.startDelivery(ownerId, orderId));
     }
 
+    @Order
     @PatchMapping("/{orderId}/complete")
-    public ResponseEntity<Void> completeDelivery(
+    public ResponseEntity<OrderStatusResponseDto> completeDelivery(
             @SessionAttribute(name = "LOGIN_USER") Long ownerId,
             @PathVariable Long orderId
     ) {
-        ownerOrderService.completeDelivery(ownerId, orderId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ownerOrderService.completeDelivery(ownerId, orderId));
     }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/controller/OwnerOrderController.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/controller/OwnerOrderController.java
@@ -29,4 +29,31 @@ public class OwnerOrderController {
         ownerOrderService.rejectOrder(ownerId, orderId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/{orderId}/cook")
+    public ResponseEntity<Void> startCooking(
+            @SessionAttribute(name = "LOGIN_USER") Long ownerId,
+            @PathVariable Long orderId
+    ) {
+        ownerOrderService.startCooking(ownerId, orderId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{orderId}/deliver")
+    public ResponseEntity<Void> startDelivery(
+            @SessionAttribute(name = "LOGIN_USER") Long ownerId,
+            @PathVariable Long orderId
+    ) {
+        ownerOrderService.startDelivery(ownerId, orderId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{orderId}/complete")
+    public ResponseEntity<Void> completeDelivery(
+            @SessionAttribute(name = "LOGIN_USER") Long ownerId,
+            @PathVariable Long orderId
+    ) {
+        ownerOrderService.completeDelivery(ownerId, orderId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/controller/UserOrderController.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/controller/UserOrderController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.request.PlaceOrderRequestDto;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.OrderStatusResponseDto;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.PlaceOrderResponseDto;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.service.UserOrderService;
+import xyz.tomorrowlearncamp.outsourcing.global.config.aop.annotation.Order;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +17,7 @@ public class UserOrderController {
 
     private final UserOrderService userOrderService;
 
+    @Order
     @PostMapping
     public ResponseEntity<PlaceOrderResponseDto> placeOrder(
             @SessionAttribute(name = "LOGIN_USER") Long userId,
@@ -23,12 +26,12 @@ public class UserOrderController {
         return ResponseEntity.ok(userOrderService.placeOrder(userId, dto));
     }
 
+    @Order
     @PatchMapping("/{orderId}/cancel")
-    public ResponseEntity<Void> cancelOrder(
+    public ResponseEntity<OrderStatusResponseDto> cancelOrder(
             @SessionAttribute(name = "LOGIN_USER") Long userId,
             @PathVariable Long orderId
     ) {
-        userOrderService.cancelOrder(userId, orderId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(userOrderService.cancelOrder(userId, orderId));
     }
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/dto/response/OrderStatusResponseDto.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/dto/response/OrderStatusResponseDto.java
@@ -1,0 +1,29 @@
+package xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response;
+
+import lombok.Getter;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
+
+@Getter
+public class OrderStatusResponseDto {
+    private final Long id;
+    private final Long storeId;
+    private final String storeTitle;
+    private final OrderStatus status;
+
+    public OrderStatusResponseDto(Long id, Long storeId, String storeTitle, OrderStatus status) {
+        this.id = id;
+        this.storeId = storeId;
+        this.storeTitle = storeTitle;
+        this.status = status;
+    }
+
+    public static OrderStatusResponseDto from(UserOrderEntity order) {
+        return new OrderStatusResponseDto(
+                order.getId(),
+                order.getStore().getStoreId(),
+                order.getStore().getStoreTitle(),
+                order.getOrderStatus()
+        );
+    }
+}

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderEntity.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/entity/UserOrderEntity.java
@@ -39,7 +39,7 @@ public class UserOrderEntity {
 
     public UserOrderEntity(UserEntity user, StoreEntity store,  int totalPrice, String payment) {
         this.user = user;
-      this.store = store;
+        this.store = store;
         this.totalPrice = totalPrice;
         this.payment = payment;
         this.orderStatus = OrderStatus.PENDING; // 기본값 설정

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/enums/ErrorOrderMessage.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/enums/ErrorOrderMessage.java
@@ -5,12 +5,17 @@ import lombok.Getter;
 @Getter
 public enum ErrorOrderMessage {
     CANNOT_CANCEL_ORDER("취소할 수 없는 주문입니다."),
-    ONLY_OWNER_CAN_ACCEPT("본인의 가게 주문만 수락할 수 있습니다."),
-    ONLY_OWNER_CAN_REJECT("본인의 가게 주문만 거절할 수 있습니다."),
     ONLY_USER_CAN_CANCEL("본인의 주문만 취소할 수 있습니다."),
     ORDER_NOT_FOUND("주문 내역이 존재하지 않습니다."),
     MINIMUM_ORDER_NOT_MET("최소 주문 금액 이상 주문해야 합니다."),
-    NOT_BUSINESS_HOURS("현재 영업 시간이 아닙니다.");
+    NOT_BUSINESS_HOURS("현재 영업 시간이 아닙니다."),
+
+    NOT_OWNER_ORDER("본인 가게 주문만 처리할 수 있습니다."),
+    ALREADY_DELIVERING_OR_COMPLETED("이미 배달이 시작되었거나 완료된 주문입니다."),
+    MUST_BE_ACCEPTED_BEFORE_COOKING("주문 접수 후에 조리를 시작할 수 있습니다."),
+    MUST_BE_COOKING_BEFORE_DELIVERY("조리를 시작한 주문만 배달할 수 있습니다."),
+    MUST_BE_DELIVERING_BEFORE_COMPLETE("배달중인 주문만 배달 완료 처리를 할 수 있습니다."),
+    ALREADY_COMPLETED("이미 배달이 완료된 주문입니다.");
 
     private final String message;
 

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/enums/OrderStatus.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/enums/OrderStatus.java
@@ -11,6 +11,8 @@ public enum OrderStatus {
     CANCELED("주문 취소"),
     ACCEPTED("주문 접수"),
     REJECTED("주문 거절"),
+    COOKING("조리중"),
+    DELIVERING("배달중"),
     COMPLETED("배달 완료");
 
     private final String description;

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/OwnerOrderService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/OwnerOrderService.java
@@ -3,6 +3,7 @@ package xyz.tomorrowlearncamp.outsourcing.domain.order.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.ErrorOrderMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
@@ -23,7 +24,7 @@ public class OwnerOrderService {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
-            throw new InvalidRequestException(ErrorOrderMessage.ONLY_OWNER_CAN_ACCEPT.getMessage());
+            throw new InvalidRequestException(ErrorOrderMessage.NOT_OWNER_ORDER.getMessage());
         }
 
         if (!OrderStatus.PENDING.equals(order.getOrderStatus())) {
@@ -39,7 +40,7 @@ public class OwnerOrderService {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
-            throw new InvalidRequestException(ErrorOrderMessage.ONLY_OWNER_CAN_REJECT.getMessage());
+            throw new InvalidRequestException(ErrorOrderMessage.NOT_OWNER_ORDER.getMessage());
         }
 
         if (!OrderStatus.PENDING.equals(order.getOrderStatus())) {
@@ -47,6 +48,65 @@ public class OwnerOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.REJECTED);
-        orderRepository.save(order);
     }
+
+    @Transactional
+    public void startCooking(Long ownerId, Long orderId) {
+        UserOrderEntity order = userOrderService.getOrderById(orderId);
+
+        if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
+            throw new InvalidRequestException(ErrorOrderMessage.NOT_OWNER_ORDER.getMessage());
+        }
+
+        if (OrderStatus.DELIVERING.equals(order.getOrderStatus())
+        || OrderStatus.COMPLETED.equals(order.getOrderStatus())) {
+            throw new InvalidRequestException(ErrorOrderMessage.ALREADY_DELIVERING_OR_COMPLETED.getMessage());
+        }
+
+        if (!OrderStatus.ACCEPTED.equals(order.getOrderStatus())) {
+            throw new InvalidRequestException(ErrorOrderMessage.MUST_BE_ACCEPTED_BEFORE_COOKING.getMessage());
+        }
+
+        order.updateOrderStatus(OrderStatus.COOKING);
+    }
+
+    @Transactional
+    public void startDelivery(Long ownerId, Long orderId) {
+        UserOrderEntity order = userOrderService.getOrderById(orderId);
+
+        if (!ObjectUtils.nullSafeEquals(ownerId, order.getStore().getUser().getId())) {
+            throw new InvalidRequestException(ErrorOrderMessage.NOT_OWNER_ORDER.getMessage());
+        }
+
+        if (OrderStatus.DELIVERING.equals(order.getOrderStatus())
+                || OrderStatus.COMPLETED.equals(order.getOrderStatus())) {
+            throw new InvalidRequestException(ErrorOrderMessage.ALREADY_DELIVERING_OR_COMPLETED.getMessage());
+        }
+
+        if (!OrderStatus.COOKING.equals(order.getOrderStatus())) {
+            throw new InvalidRequestException(ErrorOrderMessage.MUST_BE_COOKING_BEFORE_DELIVERY.getMessage());
+        }
+
+        order.updateOrderStatus(OrderStatus.DELIVERING);
+    }
+
+    @Transactional
+    public void completeDelivery(Long ownerId, Long orderId) {
+        UserOrderEntity order = userOrderService.getOrderById(orderId);
+
+        if (!ObjectUtils.nullSafeEquals(ownerId, order.getStore().getUser().getId())) {
+            throw new InvalidRequestException(ErrorOrderMessage.NOT_OWNER_ORDER.getMessage());
+        }
+
+        if (OrderStatus.COMPLETED.equals(order.getOrderStatus())) {
+            throw new InvalidRequestException(ErrorOrderMessage.ALREADY_COMPLETED.getMessage());
+        }
+
+        if (!OrderStatus.DELIVERING.equals(order.getOrderStatus())) {
+            throw new InvalidRequestException(ErrorOrderMessage.MUST_BE_DELIVERING_BEFORE_COMPLETE.getMessage());
+        }
+
+        order.updateOrderStatus(OrderStatus.COMPLETED);
+    }
+
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/OwnerOrderService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/OwnerOrderService.java
@@ -4,10 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.OrderStatusResponseDto;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.ErrorOrderMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
-import xyz.tomorrowlearncamp.outsourcing.domain.order.repository.OrderRepository;
 import xyz.tomorrowlearncamp.outsourcing.global.exception.InvalidRequestException;
 
 import java.util.Objects;
@@ -17,10 +17,9 @@ import java.util.Objects;
 public class OwnerOrderService {
 
     private final UserOrderService userOrderService;
-    private final OrderRepository orderRepository;
 
     @Transactional
-    public void acceptOrder(Long ownerId, Long orderId) {
+    public OrderStatusResponseDto acceptOrder(Long ownerId, Long orderId) {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
@@ -32,11 +31,12 @@ public class OwnerOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.ACCEPTED);
-        orderRepository.save(order);
+
+        return OrderStatusResponseDto.from(order);
     }
 
     @Transactional
-    public void rejectOrder(Long ownerId, Long orderId) {
+    public OrderStatusResponseDto rejectOrder(Long ownerId, Long orderId) {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
@@ -48,10 +48,12 @@ public class OwnerOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.REJECTED);
+
+        return OrderStatusResponseDto.from(order);
     }
 
     @Transactional
-    public void startCooking(Long ownerId, Long orderId) {
+    public OrderStatusResponseDto startCooking(Long ownerId, Long orderId) {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!Objects.equals(ownerId, order.getStore().getUser().getId())) {
@@ -68,10 +70,12 @@ public class OwnerOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.COOKING);
+
+        return OrderStatusResponseDto.from(order);
     }
 
     @Transactional
-    public void startDelivery(Long ownerId, Long orderId) {
+    public OrderStatusResponseDto startDelivery(Long ownerId, Long orderId) {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!ObjectUtils.nullSafeEquals(ownerId, order.getStore().getUser().getId())) {
@@ -88,10 +92,12 @@ public class OwnerOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.DELIVERING);
+
+        return OrderStatusResponseDto.from(order);
     }
 
     @Transactional
-    public void completeDelivery(Long ownerId, Long orderId) {
+    public OrderStatusResponseDto completeDelivery(Long ownerId, Long orderId) {
         UserOrderEntity order = userOrderService.getOrderById(orderId);
 
         if (!ObjectUtils.nullSafeEquals(ownerId, order.getStore().getUser().getId())) {
@@ -107,6 +113,8 @@ public class OwnerOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.COMPLETED);
+
+        return OrderStatusResponseDto.from(order);
     }
 
 }

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/UserOrderService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/domain/order/service/UserOrderService.java
@@ -8,6 +8,7 @@ import xyz.tomorrowlearncamp.outsourcing.domain.cart.entity.CartEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.cart.enums.ErrorCartMessage;
 import xyz.tomorrowlearncamp.outsourcing.domain.cart.service.UserCartService;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.request.PlaceOrderRequestDto;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.OrderStatusResponseDto;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.PlaceOrderResponseDto;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
 import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.ErrorOrderMessage;
@@ -24,7 +25,6 @@ import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class UserOrderService {
 
     private final OrderRepository orderRepository;
@@ -66,7 +66,7 @@ public class UserOrderService {
     }
 
     @Transactional
-    public void cancelOrder(Long userId, Long orderId) {
+    public OrderStatusResponseDto cancelOrder(Long userId, Long orderId) {
         UserOrderEntity order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new InvalidRequestException(ErrorOrderMessage.ORDER_NOT_FOUND.getMessage()));
 
@@ -79,7 +79,8 @@ public class UserOrderService {
         }
 
         order.updateOrderStatus(OrderStatus.CANCELED);
-        orderRepository.save(order);
+
+        return OrderStatusResponseDto.from(order);
     }
 
     public UserOrderEntity getOrderById(Long orderId) {

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/global/config/aop/OrderLoggingAspect.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/global/config/aop/OrderLoggingAspect.java
@@ -1,0 +1,77 @@
+package xyz.tomorrowlearncamp.outsourcing.global.config.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.OrderStatusResponseDto;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.dto.response.PlaceOrderResponseDto;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.entity.UserOrderEntity;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.enums.OrderStatus;
+import xyz.tomorrowlearncamp.outsourcing.domain.order.service.UserOrderService;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class OrderLoggingAspect {
+
+    private final UserOrderService userOrderService;
+
+    @Around("@annotation(xyz.tomorrowlearncamp.outsourcing.global.config.aop.annotation.Order)")
+    public Object logOrderApiAccess(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+
+        if (!(result instanceof ResponseEntity<?> responseEntity)) {
+            log.warn("Response가 ResponseEntity가 아닙니다. 실제 반환 타입: {}", result.getClass().getSimpleName());
+            return result;
+        }
+
+        Object body = responseEntity.getBody();
+        if (body == null) {
+            log.warn("ResponseEntity의 body가 null입니다.");
+            return result;
+        }
+
+        // 새로운 주문 생성 시 로그
+        if (body instanceof OrderStatusResponseDto responseDto) {
+            logOrder(startTime, 
+                    responseDto.getId(),
+                    responseDto.getStoreId(), 
+                    responseDto.getStoreTitle(),
+                    responseDto.getStatus());
+            return result;
+        }
+
+        // 주문 상태 변경 시 로그
+        if (body instanceof PlaceOrderResponseDto responseDto) {
+            UserOrderEntity order = userOrderService.getOrderById(responseDto.getId());
+            logOrder(startTime, 
+                    responseDto.getId(), 
+                    order.getStore().getStoreId(),
+                    responseDto.getStoreTitle(),
+                    order.getOrderStatus());
+            return result;
+        }
+
+        log.warn("지원하지 않는 Response DTO 타입: {}", body.getClass().getSimpleName());
+        return result;
+    }
+
+    private void logOrder(long startTime, Long orderId, Long storeId, String storeTitle, OrderStatus status) {
+        log.info("[주문 로그] 요청 시각: {}, 주문 ID: {}, 가게 ID: {}, 가게명: {}, 현재 상태: {}",
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(startTime)),
+                orderId,
+                storeId,
+                storeTitle,
+                status
+        );
+    }
+}

--- a/src/main/java/xyz/tomorrowlearncamp/outsourcing/global/config/aop/annotation/Order.java
+++ b/src/main/java/xyz/tomorrowlearncamp/outsourcing/global/config/aop/annotation/Order.java
@@ -1,0 +1,9 @@
+package xyz.tomorrowlearncamp.outsourcing.global.config.aop.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Order {
+}


### PR DESCRIPTION
## 변경 사항
- `AddCartResponseDto`에 가게 이름까지 나오게 수정
- `OrderStatus`에 `COOKING`, `DELIVERING` 상태 추가
- 주문 상태 변경 API 추가 구현 및 각 상태에서 이전 상태로 돌아갈 수 없도록 예외 처리
-  주문 상태 변경 시 그에 따른 응답 DTO 반환하도록 수정
- 새로운 주문 생성, 주문 상태 변경 시 AOP 로깅 구현
    - 요청 시각, 주문 id, 가게 id, 가게명, 현재 상태 로그 출력 구현

Close #12 